### PR TITLE
[Refactor] remove `array.prototype.filter` dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,25 @@
 'use strict';
 
-var filter = require('array.prototype.filter');
+var possibleNames = [
+	'BigInt64Array',
+	'BigUint64Array',
+	'Float32Array',
+	'Float64Array',
+	'Int16Array',
+	'Int32Array',
+	'Int8Array',
+	'Uint16Array',
+	'Uint32Array',
+	'Uint8Array',
+	'Uint8ClampedArray'
+];
 
 module.exports = function availableTypedArrays() {
-	return filter([
-		'BigInt64Array',
-		'BigUint64Array',
-		'Float32Array',
-		'Float64Array',
-		'Int16Array',
-		'Int32Array',
-		'Int8Array',
-		'Uint16Array',
-		'Uint32Array',
-		'Uint8Array',
-		'Uint8ClampedArray'
-	], function (typedArray) {
-		return typeof global[typedArray] === 'function';
-	});
+	var out = [];
+	for (var i = 0; i < possibleNames.length; i++) {
+		if (typeof global[possibleNames[i]] === 'function') {
+			out[out.length] = possibleNames[i];
+		}
+	}
+	return out;
 };

--- a/package.json
+++ b/package.json
@@ -77,8 +77,5 @@
 		"commitLimit": false,
 		"backfillLimit": false,
 		"hideCredit": true
-	},
-	"dependencies": {
-		"array.prototype.filter": "^1.0.0"
 	}
 }


### PR DESCRIPTION
It unnecessarily adds 37 kB to the bundle size.

See https://bundlephobia.com/result?p=array.prototype.filter@1.0.0